### PR TITLE
Fixes the typo  App loction/window.pathname to App location/window.pa…

### DIFF
--- a/03_Basic_Routing/src/Components/BasicRouting.js
+++ b/03_Basic_Routing/src/Components/BasicRouting.js
@@ -7,7 +7,7 @@ export default class BasicRouting extends Component {
     return (
       <div>
       <h1>BasicRouting</h1>
-      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App loction/window.pathname.</p>
+      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App location/window.pathname.</p>
       <p>Select a level from Left Navigation to view the content, also notice the change in URL.</p>
       <div className="leftNavi">
       	<ul>

--- a/05_Miss/src/Components/BasicRouting.js
+++ b/05_Miss/src/Components/BasicRouting.js
@@ -7,7 +7,7 @@ export default class BasicRouting extends Component {
     return (
       <div>
       <h1>BasicRouting</h1>
-      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App loction/window.pathname.</p>
+      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App location/window.pathname.</p>
       <p>Select a level from Left Navigation to view the content, also notice the change in URL.</p>
       <div className="leftNavi">
       	<ul>

--- a/06_Query_Params/src/Components/BasicRouting.js
+++ b/06_Query_Params/src/Components/BasicRouting.js
@@ -7,7 +7,7 @@ export default class BasicRouting extends Component {
     return (
       <div>
       <h1>BasicRouting</h1>
-      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App loction/window.pathname.</p>
+      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App location/window.pathname.</p>
       <p>Select a level from Left Navigation to view the content, also notice the change in URL.</p>
       <div className="leftNavi">
       	<ul>

--- a/07_Recurssive_Paths/src/Components/BasicRouting.js
+++ b/07_Recurssive_Paths/src/Components/BasicRouting.js
@@ -7,7 +7,7 @@ export default class BasicRouting extends Component {
     return (
       <div>
       <h1>BasicRouting</h1>
-      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App loction/window.pathname.</p>
+      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App location/window.pathname.</p>
       <p>Select a level from Left Navigation to view the content, also notice the change in URL.</p>
       <div className="leftNavi">
       	<ul>

--- a/08_Redirects_and_Authentication/src/Components/BasicRouting.js
+++ b/08_Redirects_and_Authentication/src/Components/BasicRouting.js
@@ -7,7 +7,7 @@ export default class BasicRouting extends Component {
     return (
       <div>
       <h1>BasicRouting</h1>
-      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App loction/window.pathname.</p>
+      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App location/window.pathname.</p>
       <p>Select a level from Left Navigation to view the content, also notice the change in URL.</p>
       <div className="leftNavi">
       	<ul>

--- a/09_Router_Config/src/Components/BasicRouting.js
+++ b/09_Router_Config/src/Components/BasicRouting.js
@@ -7,7 +7,7 @@ export default class BasicRouting extends Component {
     return (
       <div>
       <h1>BasicRouting</h1>
-      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App loction/window.pathname.</p>
+      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App location/window.pathname.</p>
       <p>Select a level from Left Navigation to view the content, also notice the change in URL.</p>
       <div className="leftNavi">
       	<ul>

--- a/10_Server_Rendering/src/Components/BasicRouting.js
+++ b/10_Server_Rendering/src/Components/BasicRouting.js
@@ -7,7 +7,7 @@ export default class BasicRouting extends Component {
     return (
       <div>
       <h1>BasicRouting</h1>
-      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App loction/window.pathname.</p>
+      <p>With the help of "Match" Component we can specify the Component we want to render for a particular pattern of the App location/window.pathname.</p>
       <p>Select a level from Left Navigation to view the content, also notice the change in URL.</p>
       <div className="leftNavi">
       	<ul>


### PR DESCRIPTION
Just an OCD spelling fix.  There are typos in that gets rendered in each page.  changes App loction/window.pathname to App location/window.pathname